### PR TITLE
(docs) Removed notice no longer valid when building on linux

### DIFF
--- a/docs/input/docs/building/linux.md
+++ b/docs/input/docs/building/linux.md
@@ -18,12 +18,3 @@ All other dependencies will be automatically downloaded when invoking the build 
 downloaded/cloned repository.
 2. After that just type `sh build.sh` and everything will be automatically built and all unit tests
 will run.
-
-:::{.alert .alert-warning}
-There is currently a small bug in some versions of the .NET Core library wich causes
-a build failure when trying to use the `dotnet` utility,
-to work around this problem you will need to export the path to the mono library directory by
-doing the following before calling the build script:
-`export FrameworkPathOverride=/usr/lib/mono/4.5/`
-*(Change the path to the actual location of your mono installation directory)*
-:::


### PR DESCRIPTION
While not strictly necessary to open as a PR, I'm doing this to test out the mergify rules.