### PR TITLE
(maint) Override codecov tool being used

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,7 +4,7 @@ codecov:
     - !travis-ci
 
 coverage:
-  range: "80-100"
+  range: 80..100
 
 comment:
   behavior: new

--- a/recipe.cake
+++ b/recipe.cake
@@ -22,6 +22,9 @@ BuildParameters.SetParameters(
     shouldUseTargetFrameworkPath: false);
 
 ToolSettings.SetToolSettings(context: Context);
+ToolSettings.SetToolPreprocessorDirectives(
+    codecovTool: "#tool nuget:?package=CodecovUploader&version=0.5.0"
+);
 
 BuildParameters.PrintParameters(Context);
 


### PR DESCRIPTION
The old codecov-exe tool that was being used to generate coverage report has stopped working quite some time ago, and it is required to use the new codecovuploader instead.